### PR TITLE
Get throbber image properly. Parallel init ops. Reset parts of form if language or part of speech is changed.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,2 @@
-- what happens if you move back into a previous field
+- retrieve list of functions from wikifunctions wiki
 

--- a/index.html
+++ b/index.html
@@ -82,14 +82,14 @@
       <span id="input-forms">
         <input list="forms"> <br>
       </span>
-      <span onclick="addfeature('input-forms')" class="action" id="addfeature" hide>add feature</span><span class="smalltext"> Leave blank to use lemma</span>
+      <span onclick="addfeature('input-forms')" class="action" id="addinputfeature" hide>add feature</span><span class="smalltext"> Leave blank to use lemma</span>
     </p>
     <p id="output-choice" hidden>
       Output form <br>
       <span id="output-forms">
         <input list="forms"> <br>
       </span>
-      <span onclick="addfeature('output-forms')" class="action" id="addfeature" hide>add feature</span> <span class="smalltext">or</span> <span onclick="getready()" class="action" id="getready" hide>continue</span>
+      <span onclick="addfeature('output-forms')" class="action" id="addoutputfeature" hide>add feature</span> <span class="smalltext">or</span> <span onclick="getready()" class="action" id="getready" hide>continue</span>
     </p>
     <p id="formcount">&nbsp;</p>
     <p id="lemma-filter-input" hidden>
@@ -116,8 +116,10 @@
     </p>
     <p id="statistics"></p>
     <table id="output" hidden>
-      <tr><th>Lexeme</th><th>Lemma</th><th>Input</th></th><th>Recorded</th><th>Function</th><th>OK</th></tr>
-    </table>
+      <thead>
+        <tr><th>Lexeme</th><th>Lemma</th><th>Input</th></th><th>Recorded</th><th>Function</th><th>OK</th></tr>
+      </thead>
+      <tbody id="output-body"></tbody>   </table>
   </body>
   <datalist id="languages"></datalist>
   <datalist id="pos"> </datalist>
@@ -219,6 +221,7 @@ async function filllanguage() {
   }
 }
 
+document.getElementById('language-select').value = ''
 createthrobber()
 filllanguage()
 countlexemes()
@@ -238,6 +241,7 @@ async function countlexemesinlanguage(languageId) {
 }
 
 async function fillpos() {
+  resetpos()
   const languageId = document.getElementById('language-select').value.split(' ')[0]
   await countlexemesinlanguage(languageId)
   document.getElementById('pos-choice').hidden = false
@@ -266,6 +270,13 @@ async function fillpos() {
   document.getElementById('pos-select').focus()
 }
 
+function resetpos() {
+  document.getElementById('pos-choice').hidden = true
+  document.getElementById('pos-select').value=''
+  document.getElementById('lexemesinpos').innerHTML = ''
+  resetfeatures()
+}
+
 async function countlexemesinpos(languageId, posId) {
   throbelementbyid('lexemesinpos', 'Counting lexemes...')
   const query = `
@@ -283,6 +294,12 @@ async function countlexemesinpos(languageId, posId) {
 }
 
 async function fillfeatures() {
+  unready()
+  document.getElementById('input-conditions').innerHTML=''
+  document.getElementById('conditions-table').hidden = true
+  initfeatures('input-forms')
+  initfeatures('output-forms')
+
   const languageId = document.getElementById('language-select').value.split(' ')[0]
   const posId = document.getElementById('pos-select').value.split(' ')[0]
   await countlexemesinpos(languageId, posId)
@@ -310,10 +327,31 @@ async function fillfeatures() {
       result.featureLabel.value;
     forms.appendChild(option);
   }
+
   document.getElementById('conditions-choice').hidden = false
   document.getElementById('input-choice').hidden = false
-  document.getElementById('output-forms').children[0].focus()
+  document.getElementById('addinputfeature').hidden = false
+  document.getElementById('addoutputfeature').hidden = false
+  document.getElementById('input-forms').children[0].focus()
   unthrob()
+}
+
+function resetfeatures() {
+  unready()
+  document.getElementById('lexemesinpos').innerHTML = ''
+  document.getElementById('input-choice').hidden = true
+  initfeatures('input-forms')
+  document.getElementById('output-choice').hidden = true
+  initfeatures('output-forms')
+  document.getElementById('addinputfeature').hidden = true
+  document.getElementById('addoutputfeature').hidden = true
+  document.getElementById('conditions-choice').hidden = true
+  document.getElementById('conditions-table').hidden = true
+  const table = document.getElementById('input-conditions')
+  while (table.firstChild) table.removeChild(table.firstChild)
+  const proplist=document.getElementById("properties")
+  while (proplist.firstChild) proplist.removeChild(proplist.firstChild)
+  document.querySelectorAll('.conditionlist').forEach(elem => elem.remove())
 }
 
 document.getElementById("output-forms").addEventListener('keydown', event => {
@@ -329,6 +367,12 @@ function getfeatures(elementid) {
     }
   }
   return features
+}
+
+function initfeatures(elementid) {
+  element = document.getElementById(elementid)
+  while (element.children.length > 2) element.removeChild(element.lastChild)
+  element.children[0].value = ''
 }
 
 async function selectedfeature(outputselectkey) {
@@ -405,7 +449,9 @@ async function selectedfeature(outputselectkey) {
   const answer = await response.json()
   if (answer.boolean) {
     getready()
-  } 
+  } else (
+    document.getElementById('formcount').innerHTML = 'No forms meet those criteria'
+  )
 }
 
 async function addcondition() {
@@ -487,6 +533,7 @@ async function fillvalues(conditioninput) {
     }
     targetlist.setAttribute('id', targetlistid)
     targetlist.setAttribute('qidval', qidval)
+    targetlist.classList.add('conditionlist')
     document.body.append(targetlist)
 
     unthrob()
@@ -579,7 +626,6 @@ async function getready() {
   const inputfeatures = getfeatures('input-forms')
   const features = getfeatures('output-forms')
 
-  document.getElementById('addfeature').hidden = false
   await countforms(languageId, posId, inputfeatures, features)
   document.getElementById('lemma-filter-input').hidden = false
   document.getElementById('limit-choice').hidden = false
@@ -613,7 +659,25 @@ async function WikifunctionsBetaFunctionCallStringToString( zid, input ) {
   const jsonnn = JSON.parse(text)
   return jsonnn.Z22K1
 }
-	  
+
+function unready() {
+  document.getElementById('formcount').innerHTML = ''
+  document.getElementById('lemma-filter-input').hidden = true
+  if (document.getElementById('hidesuccesses').innerHTML) filterresults()
+  document.getElementById('limit-choice').hidden = true
+  document.getElementById('offset-choice').hidden = true
+  document.getElementById('function-choice').hidden = true
+  document.getElementById('button-choice').hidden = true
+  document.getElementById('lemma-filter-text').value = ''
+  document.getElementById('limit-select').value = '100'
+  document.getElementById('offset-select').value = 0
+  document.getElementById('function-select').value = 'Z801 Echo'
+  document.getElementById('output').hidden = true
+  document.getElementById('output-body').innerHTML=''
+  document.getElementById('statistics').innerHTML = ''
+  document.getElementById('button-filter').hidden = true
+}
+
 async function startcheck() {
   throbelementbyid('button-choice', 'Fetching representations...')
   const languageId = document.getElementById('language-select').value.split(' ')[0]
@@ -719,7 +783,7 @@ query += `
   document.getElementById('output').hidden = false
   for (const line of answer.results.bindings) {
 	  throbberprogress(`Checking representation ${successes + fails + 1} of ${answer.results.bindings.length}`)
-    const row = document.getElementById("output").insertRow(1)
+    const row = document.getElementById("output-body").insertRow(0)
     row.insertCell().innerHTML = `<a href="${line.lexemeId.value}">${line.lexemeId.value.split('y/')[1]}</a>`
     row.insertCell().innerHTML = line.lemma.value
     row.insertCell().innerHTML = inputfeatures.length ? line.input.value : line.lemma.value

--- a/index.html
+++ b/index.html
@@ -41,7 +41,6 @@
 	      opacity: 0;
       }
       .throbberimage {
-	      background-image:  url('https://upload.wikimedia.org/wikipedia/commons/thumb/7/7a/Ajax_loader_metal_512.gif/220px-Ajax_loader_metal_512.gif');  
 	      background-position: 0px; 
 	      background-repeat:no-repeat; 
 	      background-size: contain;
@@ -54,7 +53,7 @@
     <p>
       <a href="https://github.com/vrandezo/formcheck">Instructions</a>
     </p>
-    <p id="lexemestotal">&nbsp;</p>
+    <p id="lexemestotal">Initializing...</p>
     <p>
       Language <br>
       <input list="languages" id="language-select" onchange="fillpos()" autofocus>
@@ -148,26 +147,34 @@ function filterresults() {
   }
 }
 
-var throbdiv
-var throbtextelement
+var throbtextelement = document.createElement('span')
+var throbdiv = document.createElement('span')
+
+async function createthrobber() {
+  throbdiv.className='throbber'
+  throbtextelement.className = 'throbbertext'
+  const imageelement = document.createElement('span')
+  imageelement.className = 'throbberimage'
+  throbdiv.insertBefore(imageelement, null);
+  throbdiv.insertBefore(throbtextelement, null);
+
+  const query = 'SELECT  ?url WHERE { wd:Q1447854 wdt:P18 ?url }'
+  const sparql = queryendpoint + (encodeURI(query).replace(/#/g, '%23'))
+  response = await fetch(sparql)
+  answer = await response.json()
+  imageelement.style.backgroundImage =  `url("${answer.results.bindings[0].url.value}")`; 
+  imageelement.innerHTML = '&nbsp;&nbsp;&nbsp;'
+}
+
+
 function throbelementbyid(elementid, throbtext) {
   const targetelement = document.getElementById(elementid)
   throbelement(targetelement, throbtext)
 }
 
 function throbelement(targetelement, throbtext) {
-  if (throbdiv) unthrob()
-  throbdiv = document.createElement('span')
-  throbdiv.className='throbber'
-  targetelement.parentNode.insertBefore(throbdiv, targetelement);
-  const imageelement = document.createElement('span')
-  imageelement.innerHTML = '&nbsp;&nbsp;&nbsp;'
-  imageelement.className = 'throbberimage'
-  throbdiv.insertBefore(imageelement, null);
-  throbtextelement=document.createElement('span')
-  throbtextelement.className = 'throbbertext'
   throbberprogress(throbtext)
-  throbdiv.insertBefore(throbtextelement, null);
+  targetelement.parentNode.insertBefore(throbdiv, targetelement);
 }
 
 function throbberprogress(throbtext) {
@@ -175,13 +182,10 @@ function throbberprogress(throbtext) {
 }
 
 function unthrob() {
-  if (!throbdiv) return
 	throbdiv.remove()
-	throbdiv=null
 }
 
 async function countlexemes() {
-  throbberprogress('Counting lexemes...')
   const query = `
   select (count(?lexemeId) as ?count) {
     ?lexemeId a ontolex:LexicalEntry .
@@ -192,11 +196,9 @@ async function countlexemes() {
   const answer = await response.json()
   const count = answer.results.bindings[0].count.value
   document.getElementById('lexemestotal').innerHTML = `There are ${count} lexemes in total.`
-  unthrob()
 }
 
 async function filllanguage() {
-  throbelementbyid('lexemestotal', 'Retrieving languages...')
   const query = `
   SELECT ?language ?languageLabel WHERE {
     { select distinct ?language {
@@ -215,13 +217,13 @@ async function filllanguage() {
       result.languageLabel.value;
     languages.appendChild(option);
   }
-  countlexemes()
 }
 
+createthrobber()
 filllanguage()
+countlexemes()
 
 async function countlexemesinlanguage(languageId) {
-  throbelementbyid('lexemesinlanguage', 'Counting lexemes...')
   const query = `
   select (count(?lexemeId) as ?count) {
     ?lexemeId a ontolex:LexicalEntry .
@@ -278,7 +280,6 @@ async function countlexemesinpos(languageId, posId) {
   const answer = await response.json()
   const count = answer.results.bindings[0].count.value
   document.getElementById('lexemesinpos').innerHTML = `${count} lexemes`
-  unthrob()
 }
 
 async function fillfeatures() {

--- a/index.html
+++ b/index.html
@@ -126,17 +126,11 @@
   <datalist id="properties"></datalist>
   <datalist id="forms"></datalist>
   <datalist id="functions">
-    <option value="Z801 Echo">
-    <option value="Z10187 upper">
-    <option value="Z10056 remove whitespace">
-    <option value="Z10026 say twice">
-    <option value="Z10072 To uppercase">
-    <option value="Z10210 Add s to end">
-    <option value="Z10238 replace y at end with ies">
-    <option value="Z10242 replace ий at end with а">
+    <option value="This list of functions has not been populated">
   </datalist>
   <script>
 const queryendpoint = `https://query.wikidata.org/sparql?format=json&query=`
+const apiendpoint = `https://wikifunctions.beta.wmflabs.org/w/api.php?`
 
 function filterresults() {
   if (document.getElementById('hidesuccesses').innerHTML) {
@@ -225,6 +219,7 @@ document.getElementById('language-select').value = ''
 createthrobber()
 filllanguage()
 countlexemes()
+PopulateFunctionsDatalist('User:William_Avery/formcheck functions')
 
 async function countlexemesinlanguage(languageId) {
   const query = `
@@ -645,7 +640,7 @@ async function getready() {
  * string input the input string
  */
 async function WikifunctionsBetaFunctionCallStringToString( zid, input ) {
-  const wikifunction = `https://wikifunctions.beta.wmflabs.org/w/api.php?` +
+  const wikifunction = apiendpoint +
     `action=wikilambda_function_call&format=json&wikilambda_function_call_zobject=` +
     `%7B%20%22Z1K1%22%3A%20%22Z7%22%2C%20%22Z7K1%22%3A%20%22${zid}%22%2C%20%22` +
     `${zid}K1%22%3A%20%22${input}%22%20%7D&formatversion=2&origin=*`
@@ -658,6 +653,80 @@ async function WikifunctionsBetaFunctionCallStringToString( zid, input ) {
   const text = result.query.wikilambda_function_call.data
   const jsonnn = JSON.parse(text)
   return jsonnn.Z22K1
+}
+
+async function PopulateFunctionsDatalist(listpage) {
+  let plcontinue = ''
+  const headers = {
+    'Content-Type': 'application/json',
+    'origin': '*'
+  }
+  const titlearray = []
+  do {
+     const searchparams = {
+                        action: 'query',
+                        plnamespace: 0,
+                        pllimit: 50,
+                        titles: listpage,
+                        prop: 'links',
+                        format: 'json',
+                        origin: "*"
+                    }
+      if (plcontinue) searchparams.plcontinue = plcontinue
+
+      const res = await fetch(apiendpoint +
+            new URLSearchParams(searchparams),
+            {headers}
+      )
+
+      const result = await res.json()
+      const listpageid = Object.keys(result.query.pages)[0]
+      for (link of result.query.pages[listpageid].links) {
+        titlearray.push(link.title)
+      }
+      plcontinue =  (result.continue && result.continue.plcontinue) ? result.continue.plcontinue : ''
+
+  } while (plcontinue)
+
+
+  const zidlimit = 50
+  let start = 1
+  const sortarray = []
+  while (start <= titlearray.length) {
+    const end = start  + zidlimit
+    const searchparams = {
+                        action: 'wikilambda_fetch',
+                        zids: titlearray.slice(start, end).join('|'),
+                        format: 'json',
+                        origin: "*",
+                    }
+    const res = await fetch(apiendpoint +
+            new URLSearchParams(searchparams),
+            {headers}
+      )
+    const result = await res.json()
+    console.log(result)
+    for (const zid of Object.keys(result)) {
+      const funcdef = JSON.parse(result[zid].wikilambda_fetch)
+      for (const label of funcdef.Z2K3.Z12K1.slice(1)) {
+        if ('Z11K2' in label) {
+          sortarray.push({zid: zid, label: label.Z11K2})
+          if ('Z11K1' in label && label.Z11K1 == "Z1002")
+            break
+        }
+      }
+    }
+    start = end
+  }
+  sortarray.sort((a, b) => a.label > b.label)
+
+  const functions = document.getElementById('functions')
+  while (functions.firstChild) functions.removeChild(functions.firstChild)
+  for (const func of sortarray) {
+    const option = document.createElement('option');
+    option.value =  func.zid + ' ' + func.label;
+    functions.appendChild(option);
+  }
 }
 
 function unready() {


### PR DESCRIPTION
This is a  rather trivial change I made before I got distracted around Christmas time.

1. It retrieves the image URL for a throbber (Q1447854) in a more proper way
2. It initializes the throbber, counts the total number of lexemes in the database, and loads the languages into the select element in parallel
